### PR TITLE
Hide private and unlisted videos

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "generate-comparators": "^1.0.3",
     "moment": "^2.29.1",
     "normalize-url": "^5.3.0",
-    "remove-markdown": "^0.3.0"
+    "remove-markdown": "^0.3.0",
+    "youtube-info-streams": "^1.0.8"
+  },
+  "devDependencies": {
+    "dotenv": "^16.0.0"
   }
 }

--- a/src/_includes/meta.html
+++ b/src/_includes/meta.html
@@ -1,5 +1,5 @@
 <meta property="og:site_name" content="Some Antics" />
-{% if upload %}
+{% if upload and uploadIsPublic %}
 <meta property="og:video" content="{{ upload }}" />
 {% endif %}
 <meta property="twitter:card" content="summary_large_image" />

--- a/src/_includes/stream.html
+++ b/src/_includes/stream.html
@@ -25,7 +25,7 @@
 			<main id="main-content" style="max-width: 80ch;">
 				<time datetime="{{ date | date: 'YYYY-MM-DD' }}">{{ date | date: "MMM D, YYYY" }}</time>
 
-				{% if upload %}
+				{% if upload and uploadIsPublic %}
 				<p>{{ upload }}</p>
 				<noscript><a href="{{ upload }}">Watch stream on YouTube</a></noscript>
 				{% endif %}


### PR DESCRIPTION
Ensures that pages where the stream upload link has been provided but the stream has not yet been made public hide the big gray "unavailable" block.